### PR TITLE
feature(ui): outline SVG text

### DIFF
--- a/src/public/style/finance-element.scss
+++ b/src/public/style/finance-element.scss
@@ -58,6 +58,9 @@ $part-font-size : 1.2em;
             text{
                 font-size: 1.2em;
                 font-weight: bold;
+                paint-order: stroke;
+                stroke: #fff;
+                stroke-width: 2px;
             }
         }
 


### PR DESCRIPTION
It makes it more readable over chart lines.

<img width="1022" alt="screen shot 2017-06-20 at 14 20 00" src="https://user-images.githubusercontent.com/138627/27335292-e354ec42-55c3-11e7-88ee-f3fa321c871c.png">

Thanks to `paint-order`:

> New in SVG 2. Added primarily to allow painting the stroke of text below its fill without needing to duplicate the ‘text’ element.

via https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty