### PR TITLE
Rendre à César

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 dtc innovation
+Copyright (c) 2017 Département de la Gironde
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
La licence avait été générée automatiquement par Github et mentionnait de manière erronée le possesseur des droits d'auteur sur l'outil.