### PR TITLE
ajout d'un chiffre manquant page focus solidarité

### DIFF
--- a/src/public/js/components/screens/FocusSolidarity.js
+++ b/src/public/js/components/screens/FocusSolidarity.js
@@ -57,7 +57,7 @@ export function FocusSol({
             React.createElement('div', {}, 
                 React.createElement('p', {}, 
                     React.createElement('strong', {},
-                        "Avec 120 000 prestations allouées et xxx millions d'euros mobilisés en 2016, les dépenses de Solidarités pour soutenir les personnes fragilisées évoluent de +4,31% par rapport à 2015."
+                        "Avec 120 000 prestations allouées et 813 millions d'euros mobilisés en 2016, les dépenses de Solidarités pour soutenir les personnes fragilisées évoluent de +4,31% par rapport à 2015."
                     ),
                     ` `),
                 React.createElement(PrimaryCallToAction, {href: '#!/finance-details/DF-2', text: `en savoir plus`})


### PR DESCRIPTION
ajout d'un chiffre manquant dans le paragraphe qui détaille le graphique du pourcentage des dépenses d'actions sociales