### PR TITLE
Aligne les boutons de la constructions du budget

### DIFF
--- a/src/public/style/budget-construction.scss
+++ b/src/public/style/budget-construction.scss
@@ -163,6 +163,10 @@ $in-between-brick-space: 0.5em; // to be sync with variable of same name in Budg
         border-radius: 5px;	
         background-color: #D8D8D8;
     }
+    
+    .btn (
+        margin-top: auto;    
+    }
 
     dl{
         display: flex;

--- a/src/public/style/budget-construction.scss
+++ b/src/public/style/budget-construction.scss
@@ -164,7 +164,7 @@ $in-between-brick-space: 0.5em; // to be sync with variable of same name in Budg
         background-color: #D8D8D8;
     }
     
-    .btn (
+    .btn {
         margin-top: auto;    
     }
 


### PR DESCRIPTION
Alignement vers le bas pour rendre leur position prédictible.

<img width="1237" alt="screen shot 2017-10-20 at 17 23 59" src="https://user-images.githubusercontent.com/138627/31831450-7bde9880-b5bb-11e7-9bf6-df390f3809dd.png">
